### PR TITLE
Update Alpine so as to avoid SSL problems

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN touch src/main.rs && cargo build --target=$BUILD_TARGET --release --features
 # Copy the compiled binary to a target-independent location so it can be picked up later
 RUN cp target/$BUILD_TARGET/release/sentry-cli /usr/local/bin/sentry-cli
 
-FROM alpine:3.7
+FROM alpine:3.12
 WORKDIR /work
 RUN apk add --no-cache ca-certificates
 COPY ./docker-entrypoint.sh /


### PR DESCRIPTION
I simply updated alpine from 3.7 to 3.12, so as to avoid the SSL problem